### PR TITLE
Implement compatibility with Chrome 71+ autoplay policy

### DIFF
--- a/js/jukebox.js
+++ b/js/jukebox.js
@@ -83,6 +83,9 @@ var Jukebox = {
 		document.querySelector("#banner").innerHTML = "Click to start";
 		let onclick = () => {
 			document.body.removeEventListener("click", onclick);
+			// Resume the audio context now that the user has interacted with page
+			// https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio
+			this._ctx.resume();
 			this._next();
 		}
 		document.body.addEventListener("click", onclick);


### PR DESCRIPTION
This change adds compatibility with Chrome 71+ by accommodating the autoplay policy, which requires explicitly resuming the AudioContext after user interaction.

Details: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio